### PR TITLE
Implement calendar module infrastructure and UI

### DIFF
--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -1,0 +1,4 @@
+class ApiConstants {
+  static const String googleCalendarBaseUrl = 'https://www.googleapis.com';
+  static const String defaultCalendarId = 'primary';
+}

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -1,8 +1,5 @@
-import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
-import 'package:injectable/injectable.dart';
 
-import '../constants/api_constants.dart';
 import '../navigation/app_router.dart';
 import '../network/dio_client.dart';
 import '../../features/calendar/data/datasources/calendar_local_data_source.dart';
@@ -13,34 +10,26 @@ import '../../features/calendar/presentation/bloc/calendar_bloc.dart';
 
 final getIt = GetIt.instance;
 
-@InjectableInit()
 Future<void> configureDependencies() async {
-  // Core dependencies
-  getIt.registerSingleton<AppRouter>(AppRouter());
-  getIt.registerSingleton<DioClient>(DioClient());
-  
-  // Calendar dependencies
+  getIt.registerLazySingleton<AppRouter>(() => AppRouter());
+  getIt.registerLazySingleton<DioClient>(() => DioClient());
+
   getIt.registerLazySingleton<CalendarLocalDataSource>(
     () => CalendarLocalDataSourceImpl(),
   );
-  
+
   getIt.registerLazySingleton<CalendarRemoteDataSource>(
-    () => CalendarRemoteDataSourceImpl(
-      dio: getIt<DioClient>().getCalendarDio(''), // TODO: Add access token
-    ),
+    () => CalendarRemoteDataSourceImpl(),
   );
-  
+
   getIt.registerLazySingleton<CalendarRepository>(
     () => CalendarRepositoryImpl(
       remoteDataSource: getIt<CalendarRemoteDataSource>(),
       localDataSource: getIt<CalendarLocalDataSource>(),
     ),
   );
-  
+
   getIt.registerFactory<CalendarBloc>(
     () => CalendarBloc(calendarRepository: getIt<CalendarRepository>()),
   );
-  
-  // TODO: Add auto-generated dependency injection
-  // await getIt.init();
 }

--- a/lib/core/errors/failures.dart
+++ b/lib/core/errors/failures.dart
@@ -1,0 +1,27 @@
+import 'package:equatable/equatable.dart';
+
+abstract class Failure extends Equatable {
+  final String message;
+  final Object? cause;
+
+  const Failure(this.message, {this.cause});
+
+  @override
+  List<Object?> get props => [message, cause];
+}
+
+class ServerFailure extends Failure {
+  const ServerFailure(String message, {Object? cause}) : super(message, cause: cause);
+}
+
+class CacheFailure extends Failure {
+  const CacheFailure(String message, {Object? cause}) : super(message, cause: cause);
+}
+
+class NetworkFailure extends Failure {
+  const NetworkFailure(String message, {Object? cause}) : super(message, cause: cause);
+}
+
+class AuthenticationFailure extends Failure {
+  const AuthenticationFailure(String message, {Object? cause}) : super(message, cause: cause);
+}

--- a/lib/core/navigation/app_router.dart
+++ b/lib/core/navigation/app_router.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../features/ai/presentation/pages/ai_page.dart';
+import '../../features/calendar/presentation/pages/calendar_page.dart';
+import '../../features/home/presentation/pages/home_page.dart';
+import '../../features/settings/presentation/pages/settings_page.dart';
+
+enum AppRoute {
+  home('home'),
+  calendar('calendar'),
+  assistant('assistant'),
+  settings('settings');
+
+  const AppRoute(this.name);
+  final String name;
+}
+
+class AppRouter {
+  AppRouter() {
+    router = GoRouter(
+      routes: [
+        GoRoute(
+          name: AppRoute.home.name,
+          path: '/',
+          builder: (context, state) => const HomePage(),
+        ),
+        GoRoute(
+          name: AppRoute.calendar.name,
+          path: '/calendar',
+          builder: (context, state) => const CalendarPage(),
+        ),
+        GoRoute(
+          name: AppRoute.assistant.name,
+          path: '/assistant',
+          builder: (context, state) => const AiPage(),
+        ),
+        GoRoute(
+          name: AppRoute.settings.name,
+          path: '/settings',
+          builder: (context, state) => const SettingsPage(),
+        ),
+      ],
+      initialLocation: '/calendar',
+      debugLogDiagnostics: false,
+      errorBuilder: (context, state) {
+        return Scaffold(
+          body: Center(
+            child: Text('Страница не найдена: ${state.error}'),
+          ),
+        );
+      },
+    );
+  }
+
+  late final GoRouter router;
+}

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+
+import '../constants/api_constants.dart';
+
+class DioClient {
+  DioClient();
+
+  Dio get calendarDio {
+    final dio = Dio(
+      BaseOptions(
+        baseUrl: ApiConstants.googleCalendarBaseUrl,
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+      ),
+    );
+
+    return dio;
+  }
+}

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static ThemeData get lightTheme {
+    final colorScheme = ColorScheme.fromSeed(seedColor: Colors.indigo);
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: colorScheme.surface,
+      appBarTheme: AppBarTheme(
+        backgroundColor: colorScheme.surface,
+        foregroundColor: colorScheme.onSurface,
+      ),
+      floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: colorScheme.primary,
+        foregroundColor: colorScheme.onPrimary,
+      ),
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor: colorScheme.primary,
+        contentTextStyle: TextStyle(color: colorScheme.onPrimary),
+      ),
+    );
+  }
+
+  static ThemeData get darkTheme {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: Colors.indigo,
+      brightness: Brightness.dark,
+    );
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: colorScheme.surface,
+      appBarTheme: AppBarTheme(
+        backgroundColor: colorScheme.surface,
+        foregroundColor: colorScheme.onSurface,
+      ),
+      floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: colorScheme.primary,
+        foregroundColor: colorScheme.onPrimary,
+      ),
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor: colorScheme.primary,
+        contentTextStyle: TextStyle(color: colorScheme.onPrimary),
+      ),
+    );
+  }
+}

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -1,0 +1,29 @@
+import 'package:logger/logger.dart';
+
+class AppLogger {
+  static final Logger _logger = Logger(
+    printer: PrettyPrinter(
+      methodCount: 0,
+      errorMethodCount: 5,
+      lineLength: 80,
+      colors: true,
+      printEmojis: true,
+    ),
+  );
+
+  static void info(String message) {
+    _logger.i(message);
+  }
+
+  static void warning(String message) {
+    _logger.w(message);
+  }
+
+  static void error(String message, [Object? error, StackTrace? stackTrace]) {
+    _logger.e(message, error: error, stackTrace: stackTrace);
+  }
+
+  static void debug(String message) {
+    _logger.d(message);
+  }
+}

--- a/lib/features/ai/presentation/pages/ai_page.dart
+++ b/lib/features/ai/presentation/pages/ai_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../../../../shared/widgets/bottom_nav_bar.dart';
+
+class AiPage extends StatelessWidget {
+  const AiPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('AI ассистент')),
+      body: const Center(
+        child: Text('AI ассистент в разработке'),
+      ),
+      bottomNavigationBar: const BottomNavBar(currentIndex: 2),
+    );
+  }
+}

--- a/lib/features/calendar/data/datasources/calendar_local_data_source.dart
+++ b/lib/features/calendar/data/datasources/calendar_local_data_source.dart
@@ -1,5 +1,4 @@
 import 'package:hive/hive.dart';
-import 'package:dartz/dartz.dart';
 
 import '../../../../core/errors/failures.dart';
 import '../../../../core/utils/logger.dart';
@@ -7,20 +6,20 @@ import '../models/event_model.dart';
 
 abstract class CalendarLocalDataSource {
   Future<List<EventModel>> getCachedEvents();
-  
+
   Future<void> cacheEvents(List<EventModel> events);
-  
+
   Future<void> cacheEvent(EventModel event);
-  
+
   Future<void> removeCachedEvent(String eventId);
-  
+
   Future<void> clearCache();
 }
 
 class CalendarLocalDataSourceImpl implements CalendarLocalDataSource {
   static const String _eventsBoxName = 'calendar_events';
   static const String _eventsKey = 'events';
-  
+
   late Box<Map> _box;
 
   Future<void> _initBox() async {
@@ -35,18 +34,18 @@ class CalendarLocalDataSourceImpl implements CalendarLocalDataSource {
   Future<List<EventModel>> getCachedEvents() async {
     try {
       await _initBox();
-      
+
       final cachedData = _box.get(_eventsKey);
       if (cachedData != null) {
         final List<dynamic> eventsJson = cachedData['events'] ?? [];
         final events = eventsJson
             .map((json) => EventModel.fromJson(Map<String, dynamic>.from(json)))
             .toList();
-        
+
         AppLogger.info('Retrieved ${events.length} cached events');
         return events;
       }
-      
+
       AppLogger.info('No cached events found');
       return [];
     } catch (e) {
@@ -59,13 +58,13 @@ class CalendarLocalDataSourceImpl implements CalendarLocalDataSource {
   Future<void> cacheEvents(List<EventModel> events) async {
     try {
       await _initBox();
-      
+
       final eventsJson = events.map((event) => event.toJson()).toList();
       await _box.put(_eventsKey, {
         'events': eventsJson,
         'cached_at': DateTime.now().toIso8601String(),
       });
-      
+
       AppLogger.info('Cached ${events.length} events');
     } catch (e) {
       AppLogger.error('Error caching events: $e');
@@ -77,16 +76,16 @@ class CalendarLocalDataSourceImpl implements CalendarLocalDataSource {
   Future<void> cacheEvent(EventModel event) async {
     try {
       await _initBox();
-      
+
       final cachedEvents = await getCachedEvents();
       final existingIndex = cachedEvents.indexWhere((e) => e.id == event.id);
-      
+
       if (existingIndex != -1) {
         cachedEvents[existingIndex] = event;
       } else {
         cachedEvents.add(event);
       }
-      
+
       await cacheEvents(cachedEvents);
       AppLogger.info('Cached event: ${event.id}');
     } catch (e) {
@@ -99,10 +98,10 @@ class CalendarLocalDataSourceImpl implements CalendarLocalDataSource {
   Future<void> removeCachedEvent(String eventId) async {
     try {
       await _initBox();
-      
+
       final cachedEvents = await getCachedEvents();
       cachedEvents.removeWhere((event) => event.id == eventId);
-      
+
       await cacheEvents(cachedEvents);
       AppLogger.info('Removed cached event: $eventId');
     } catch (e) {

--- a/lib/features/calendar/domain/entities/event.dart
+++ b/lib/features/calendar/domain/entities/event.dart
@@ -1,0 +1,75 @@
+import 'package:equatable/equatable.dart';
+
+class Event extends Equatable {
+  const Event({
+    required this.id,
+    required this.title,
+    required this.startTime,
+    required this.endTime,
+    this.description,
+    this.location,
+    this.isAllDay = false,
+    this.attendees = const [],
+    this.recurrence,
+    this.reminderMinutes = 15,
+  });
+
+  final String id;
+  final String title;
+  final String? description;
+  final DateTime startTime;
+  final DateTime endTime;
+  final String? location;
+  final bool isAllDay;
+  final List<String> attendees;
+  final String? recurrence;
+  final int reminderMinutes;
+
+  Duration get duration => endTime.difference(startTime);
+
+  bool occursOnDate(DateTime date) {
+    final eventDate = DateTime(startTime.year, startTime.month, startTime.day);
+    final targetDate = DateTime(date.year, date.month, date.day);
+    return eventDate == targetDate;
+  }
+
+  Event copyWith({
+    String? id,
+    String? title,
+    String? description,
+    DateTime? startTime,
+    DateTime? endTime,
+    String? location,
+    bool? isAllDay,
+    List<String>? attendees,
+    String? recurrence,
+    int? reminderMinutes,
+  }) {
+    return Event(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      location: location ?? this.location,
+      isAllDay: isAllDay ?? this.isAllDay,
+      attendees: attendees ?? this.attendees,
+      recurrence: recurrence ?? this.recurrence,
+      reminderMinutes: reminderMinutes ?? this.reminderMinutes,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        description,
+        startTime,
+        endTime,
+        location,
+        isAllDay,
+        attendees,
+        recurrence,
+        reminderMinutes,
+      ];
+}

--- a/lib/features/calendar/domain/repositories/calendar_repository.dart
+++ b/lib/features/calendar/domain/repositories/calendar_repository.dart
@@ -1,0 +1,27 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../entities/event.dart';
+
+abstract class CalendarRepository {
+  Future<Either<Failure, List<Event>>> getEvents({
+    required DateTime startDate,
+    required DateTime endDate,
+  });
+
+  Future<Either<Failure, Event>> createEvent(Event event);
+
+  Future<Either<Failure, Event>> updateEvent(Event event);
+
+  Future<Either<Failure, void>> deleteEvent(String eventId);
+
+  Future<Either<Failure, List<Event>>> searchEvents(String query);
+
+  Future<Either<Failure, List<DateTime>>> findFreeSlots({
+    required DateTime startDate,
+    required DateTime endDate,
+    required Duration duration,
+  });
+
+  Future<Either<Failure, void>> syncWithGoogle();
+}

--- a/lib/features/calendar/domain/usecases/create_event.dart
+++ b/lib/features/calendar/domain/usecases/create_event.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../entities/event.dart';
+import '../repositories/calendar_repository.dart';
+
+class CreateCalendarEvent {
+  const CreateCalendarEvent(this.repository);
+
+  final CalendarRepository repository;
+
+  Future<Either<Failure, Event>> call(Event event) {
+    return repository.createEvent(event);
+  }
+}

--- a/lib/features/calendar/domain/usecases/delete_event.dart
+++ b/lib/features/calendar/domain/usecases/delete_event.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../repositories/calendar_repository.dart';
+
+class DeleteCalendarEvent {
+  const DeleteCalendarEvent(this.repository);
+
+  final CalendarRepository repository;
+
+  Future<Either<Failure, void>> call(String eventId) {
+    return repository.deleteEvent(eventId);
+  }
+}

--- a/lib/features/calendar/domain/usecases/find_free_slots.dart
+++ b/lib/features/calendar/domain/usecases/find_free_slots.dart
@@ -1,0 +1,22 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../repositories/calendar_repository.dart';
+
+class FindFreeSlots {
+  const FindFreeSlots(this.repository);
+
+  final CalendarRepository repository;
+
+  Future<Either<Failure, List<DateTime>>> call({
+    required DateTime startDate,
+    required DateTime endDate,
+    required Duration duration,
+  }) {
+    return repository.findFreeSlots(
+      startDate: startDate,
+      endDate: endDate,
+      duration: duration,
+    );
+  }
+}

--- a/lib/features/calendar/domain/usecases/get_events.dart
+++ b/lib/features/calendar/domain/usecases/get_events.dart
@@ -1,0 +1,18 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../entities/event.dart';
+import '../repositories/calendar_repository.dart';
+
+class GetEvents {
+  const GetEvents(this.repository);
+
+  final CalendarRepository repository;
+
+  Future<Either<Failure, List<Event>>> call({
+    required DateTime startDate,
+    required DateTime endDate,
+  }) {
+    return repository.getEvents(startDate: startDate, endDate: endDate);
+  }
+}

--- a/lib/features/calendar/domain/usecases/search_events.dart
+++ b/lib/features/calendar/domain/usecases/search_events.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../entities/event.dart';
+import '../repositories/calendar_repository.dart';
+
+class SearchEvents {
+  const SearchEvents(this.repository);
+
+  final CalendarRepository repository;
+
+  Future<Either<Failure, List<Event>>> call(String query) {
+    return repository.searchEvents(query);
+  }
+}

--- a/lib/features/calendar/domain/usecases/sync_with_google.dart
+++ b/lib/features/calendar/domain/usecases/sync_with_google.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../repositories/calendar_repository.dart';
+
+class SyncWithGoogle {
+  const SyncWithGoogle(this.repository);
+
+  final CalendarRepository repository;
+
+  Future<Either<Failure, void>> call() {
+    return repository.syncWithGoogle();
+  }
+}

--- a/lib/features/calendar/domain/usecases/update_event.dart
+++ b/lib/features/calendar/domain/usecases/update_event.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/errors/failures.dart';
+import '../entities/event.dart';
+import '../repositories/calendar_repository.dart';
+
+class UpdateCalendarEvent {
+  const UpdateCalendarEvent(this.repository);
+
+  final CalendarRepository repository;
+
+  Future<Either<Failure, Event>> call(Event event) {
+    return repository.updateEvent(event);
+  }
+}

--- a/lib/features/calendar/presentation/bloc/calendar_state.dart
+++ b/lib/features/calendar/presentation/bloc/calendar_state.dart
@@ -14,64 +14,44 @@ class CalendarInitial extends CalendarState {}
 class CalendarLoading extends CalendarState {}
 
 class CalendarLoaded extends CalendarState {
-  final List<Event> events;
-  final DateTime selectedDate;
-  final List<Event> filteredEvents;
-
   const CalendarLoaded({
     required this.events,
     required this.selectedDate,
     this.filteredEvents = const [],
+    this.statusMessage,
   });
+
+  final List<Event> events;
+  final DateTime selectedDate;
+  final List<Event> filteredEvents;
+  final String? statusMessage;
 
   CalendarLoaded copyWith({
     List<Event>? events,
     DateTime? selectedDate,
     List<Event>? filteredEvents,
+    String? statusMessage,
+    bool clearStatusMessage = false,
   }) {
     return CalendarLoaded(
       events: events ?? this.events,
       selectedDate: selectedDate ?? this.selectedDate,
       filteredEvents: filteredEvents ?? this.filteredEvents,
+      statusMessage: clearStatusMessage
+          ? null
+          : statusMessage ?? this.statusMessage,
     );
   }
 
   @override
-  List<Object?> get props => [events, selectedDate, filteredEvents];
+  List<Object?> get props => [events, selectedDate, filteredEvents, statusMessage];
 }
 
 class CalendarError extends CalendarState {
-  final String message;
-
   const CalendarError(this.message);
+
+  final String message;
 
   @override
   List<Object?> get props => [message];
-}
-
-class EventCreated extends CalendarState {
-  final Event event;
-
-  const EventCreated(this.event);
-
-  @override
-  List<Object?> get props => [event];
-}
-
-class EventUpdated extends CalendarState {
-  final Event event;
-
-  const EventUpdated(this.event);
-
-  @override
-  List<Object?> get props => [event];
-}
-
-class EventDeleted extends CalendarState {
-  final String eventId;
-
-  const EventDeleted(this.eventId);
-
-  @override
-  List<Object?> get props => [eventId];
 }

--- a/lib/features/calendar/presentation/pages/calendar_page.dart
+++ b/lib/features/calendar/presentation/pages/calendar_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/di/injection.dart';
 import '../../../../shared/widgets/bottom_nav_bar.dart';
+import '../../domain/entities/event.dart';
 import '../bloc/calendar_bloc.dart';
 import '../bloc/calendar_event.dart';
 import '../bloc/calendar_state.dart';
@@ -34,81 +35,52 @@ class CalendarView extends StatelessWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.search),
-            onPressed: () {
-              _showSearchDialog(context);
-            },
+            onPressed: () => _showSearchDialog(context),
           ),
           IconButton(
             icon: const Icon(Icons.refresh),
-            onPressed: () {
-              context.read<CalendarBloc>().add(RefreshCalendar());
-            },
+            onPressed: () => context.read<CalendarBloc>().add(RefreshCalendar()),
           ),
         ],
       ),
-      body: BlocBuilder<CalendarBloc, CalendarState>(
+      body: BlocConsumer<CalendarBloc, CalendarState>(
+        listener: (context, state) {
+          if (state is CalendarLoaded && state.statusMessage != null) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(
+                SnackBar(content: Text(state.statusMessage!)),
+              );
+          }
+        },
         builder: (context, state) {
           if (state is CalendarLoading) {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
+            return const Center(child: CircularProgressIndicator());
           } else if (state is CalendarError) {
-            return Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.error_outline,
-                    size: 64,
-                    color: Colors.red[400],
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    'Ошибка загрузки календаря',
-                    style: Theme.of(context).textTheme.headlineSmall,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    state.message,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(color: Colors.grey[600]),
-                  ),
-                  const SizedBox(height: 24),
-                  ElevatedButton(
-                    onPressed: () {
-                      context.read<CalendarBloc>().add(RefreshCalendar());
-                    },
-                    child: const Text('Повторить'),
-                  ),
-                ],
-              ),
-            );
+            return _CalendarError(message: state.message);
           } else if (state is CalendarLoaded) {
             return Column(
               children: [
-                // Calendar header
                 _buildCalendarHeader(context, state),
-                
-                // Events list
                 Expanded(
                   child: state.filteredEvents.isEmpty
-                      ? _buildEmptyState(context)
-                      : _buildEventsList(context, state),
+                      ? const _EmptyState()
+                      : _EventsList(
+                          events: state.filteredEvents,
+                          onEdit: (event) => _showEditEventDialog(context, event),
+                          onDelete: (event) => _showDeleteConfirmation(context, event),
+                        ),
                 ),
               ],
             );
-          } else {
-            return const Center(
-              child: Text('Нажмите для загрузки календаря'),
-            );
           }
+
+          return const Center(child: CircularProgressIndicator());
         },
       ),
       bottomNavigationBar: const BottomNavBar(currentIndex: 1),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          _showCreateEventDialog(context);
-        },
+        onPressed: () => _showCreateEventDialog(context),
         child: const Icon(Icons.add),
       ),
     );
@@ -126,8 +98,8 @@ class CalendarView extends StatelessWidget {
               Text(
                 'События',
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
+                      fontWeight: FontWeight.bold,
+                    ),
               ),
               Text(
                 '${state.filteredEvents.length} событий',
@@ -136,152 +108,55 @@ class CalendarView extends StatelessWidget {
             ],
           ),
           TextButton.icon(
-            onPressed: () {
-              _showDatePicker(context);
-            },
+            onPressed: () => _showDatePicker(context),
             icon: const Icon(Icons.calendar_today),
             label: Text(
-              '${state.selectedDate.day}.${state.selectedDate.month}.${state.selectedDate.year}',
+              '${state.selectedDate.day.toString().padLeft(2, '0')}.${state.selectedDate.month.toString().padLeft(2, '0')}.${state.selectedDate.year}',
             ),
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildEmptyState(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.event_note,
-            size: 64,
-            color: Colors.grey[400],
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Нет событий',
-            style: Theme.of(context).textTheme.headlineSmall,
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Создайте первое событие',
-            style: TextStyle(color: Colors.grey[600]),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildEventsList(BuildContext context, CalendarLoaded state) {
-    return ListView.builder(
-      padding: const EdgeInsets.all(16),
-      itemCount: state.filteredEvents.length,
-      itemBuilder: (context, index) {
-        final event = state.filteredEvents[index];
-        return Card(
-          margin: const EdgeInsets.only(bottom: 8),
-          child: ListTile(
-            leading: CircleAvatar(
-              backgroundColor: Theme.of(context).colorScheme.primary,
-              child: Text(
-                event.startTime.hour.toString().padLeft(2, '0'),
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-            title: Text(
-              event.title,
-              style: const TextStyle(fontWeight: FontWeight.w500),
-            ),
-            subtitle: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (event.description != null)
-                  Text(event.description!),
-                const SizedBox(height: 4),
-                Text(
-                  '${event.startTime.hour.toString().padLeft(2, '0')}:${event.startTime.minute.toString().padLeft(2, '0')} - ${event.endTime.hour.toString().padLeft(2, '0')}:${event.endTime.minute.toString().padLeft(2, '0')}',
-                  style: TextStyle(
-                    color: Colors.grey[600],
-                    fontSize: 12,
-                  ),
-                ),
-                if (event.location != null)
-                  Text(
-                    '📍 ${event.location}',
-                    style: TextStyle(
-                      color: Colors.grey[600],
-                      fontSize: 12,
-                    ),
-                  ),
-              ],
-            ),
-            trailing: PopupMenuButton<String>(
-              onSelected: (value) {
-                if (value == 'edit') {
-                  _showEditEventDialog(context, event);
-                } else if (value == 'delete') {
-                  _showDeleteConfirmation(context, event);
-                }
-              },
-              itemBuilder: (context) => [
-                const PopupMenuItem(
-                  value: 'edit',
-                  child: Row(
-                    children: [
-                      Icon(Icons.edit),
-                      SizedBox(width: 8),
-                      Text('Редактировать'),
-                    ],
-                  ),
-                ),
-                const PopupMenuItem(
-                  value: 'delete',
-                  child: Row(
-                    children: [
-                      Icon(Icons.delete),
-                      SizedBox(width: 8),
-                      Text('Удалить'),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
     );
   }
 
   void _showSearchDialog(BuildContext context) {
+    final queryController = TextEditingController();
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Поиск событий'),
         content: TextField(
+          controller: queryController,
           decoration: const InputDecoration(
-            hintText: 'Введите название события',
+            hintText: 'Введите название или описание',
             border: OutlineInputBorder(),
           ),
-          onSubmitted: (query) {
-            if (query.isNotEmpty) {
-              context.read<CalendarBloc>().add(SearchEvents(query));
-              Navigator.pop(context);
-            }
-          },
+          textInputAction: TextInputAction.search,
+          onSubmitted: (query) => _search(context, query),
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Отмена'),
+            onPressed: () {
+              Navigator.pop(context);
+              context.read<CalendarBloc>().add(const SearchEvents(''));
+            },
+            child: const Text('Сбросить'),
+          ),
+          TextButton(
+            onPressed: () {
+              _search(context, queryController.text);
+              Navigator.pop(context);
+            },
+            child: const Text('Найти'),
           ),
         ],
       ),
     );
+  }
+
+  void _search(BuildContext context, String query) {
+    context.read<CalendarBloc>().add(SearchEvents(query.trim()));
   }
 
   void _showDatePicker(BuildContext context) {
@@ -298,20 +173,57 @@ class CalendarView extends StatelessWidget {
   }
 
   void _showCreateEventDialog(BuildContext context) {
-    // TODO: Implement create event dialog
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Создание события - в разработке')),
+    final bloc = context.read<CalendarBloc>();
+    final selectedDate = bloc.state is CalendarLoaded
+        ? (bloc.state as CalendarLoaded).selectedDate
+        : DateTime.now();
+    final formData = _EventFormData.initial(selectedDate: selectedDate);
+
+    _showEventFormDialog(
+      context,
+      title: 'Новое событие',
+      formData: formData,
+      onSubmit: (data) {
+        final event = Event(
+          id: data.id,
+          title: data.title,
+          description: data.description,
+          startTime: data.startDateTime,
+          endTime: data.endDateTime,
+          location: data.location,
+          isAllDay: data.isAllDay,
+          attendees: data.attendees,
+          reminderMinutes: data.reminderMinutes,
+        );
+        bloc.add(CreateEvent(event));
+      },
     );
   }
 
-  void _showEditEventDialog(BuildContext context, event) {
-    // TODO: Implement edit event dialog
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Редактирование события - в разработке')),
+  void _showEditEventDialog(BuildContext context, Event event) {
+    final formData = _EventFormData.fromEvent(event);
+
+    _showEventFormDialog(
+      context,
+      title: 'Редактирование события',
+      formData: formData,
+      onSubmit: (data) {
+        final updatedEvent = event.copyWith(
+          title: data.title,
+          description: data.description,
+          startTime: data.startDateTime,
+          endTime: data.endDateTime,
+          location: data.location,
+          attendees: data.attendees,
+          isAllDay: data.isAllDay,
+          reminderMinutes: data.reminderMinutes,
+        );
+        context.read<CalendarBloc>().add(UpdateEvent(updatedEvent));
+      },
     );
   }
 
-  void _showDeleteConfirmation(BuildContext context, event) {
+  void _showDeleteConfirmation(BuildContext context, Event event) {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -331,6 +243,547 @@ class CalendarView extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+
+  void _showEventFormDialog(
+    BuildContext context, {
+    required String title,
+    required _EventFormData formData,
+    required ValueChanged<_EventFormData> onSubmit,
+  }) {
+    final formKey = GlobalKey<FormState>();
+    final titleController = TextEditingController(text: formData.title);
+    final descriptionController = TextEditingController(text: formData.description);
+    final locationController = TextEditingController(text: formData.location);
+    final attendeesController = TextEditingController(text: formData.attendees.join(', '));
+
+    TimeOfDay startTime = TimeOfDay.fromDateTime(formData.startDateTime);
+    TimeOfDay endTime = TimeOfDay.fromDateTime(formData.endDateTime);
+    DateTime selectedDate = formData.startDateTime;
+    bool isAllDay = formData.isAllDay;
+    int reminderMinutes = formData.reminderMinutes;
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            Future<void> pickTime({required bool forStart}) async {
+              final initialTime = forStart ? startTime : endTime;
+              final result = await showTimePicker(
+                context: context,
+                initialTime: initialTime,
+              );
+
+              if (result != null) {
+                setState(() {
+                  if (forStart) {
+                    startTime = result;
+                    if (!isAllDay && _combine(selectedDate, endTime).isBefore(_combine(selectedDate, startTime))) {
+                      endTime = TimeOfDay(
+                        hour: (startTime.hour + 1) % 24,
+                        minute: startTime.minute,
+                      );
+                    }
+                  } else {
+                    endTime = result;
+                  }
+                });
+              }
+            }
+
+            Future<void> pickDate() async {
+              final result = await showDatePicker(
+                context: context,
+                initialDate: selectedDate,
+                firstDate: DateTime.now().subtract(const Duration(days: 365)),
+                lastDate: DateTime.now().add(const Duration(days: 365)),
+              );
+
+              if (result != null) {
+                setState(() => selectedDate = result);
+              }
+            }
+
+            return AlertDialog(
+              title: Text(title),
+              content: SingleChildScrollView(
+                child: Form(
+                  key: formKey,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      TextFormField(
+                        controller: titleController,
+                        decoration: const InputDecoration(
+                          labelText: 'Название',
+                          border: OutlineInputBorder(),
+                        ),
+                        validator: (value) {
+                          if (value == null || value.trim().isEmpty) {
+                            return 'Введите название события';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: descriptionController,
+                        decoration: const InputDecoration(
+                          labelText: 'Описание',
+                          border: OutlineInputBorder(),
+                        ),
+                        maxLines: 2,
+                      ),
+                      const SizedBox(height: 12),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextButton.icon(
+                              onPressed: pickDate,
+                              icon: const Icon(Icons.event),
+                              label: Text(
+                                '${selectedDate.day.toString().padLeft(2, '0')}.${selectedDate.month.toString().padLeft(2, '0')}.${selectedDate.year}',
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: CheckboxListTile(
+                              value: isAllDay,
+                              onChanged: (value) => setState(() => isAllDay = value ?? false),
+                              title: const Text('Весь день'),
+                              controlAffinity: ListTileControlAffinity.leading,
+                            ),
+                          ),
+                        ],
+                      ),
+                      if (!isAllDay) ...[
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextButton.icon(
+                                onPressed: () => pickTime(forStart: true),
+                                icon: const Icon(Icons.schedule),
+                                label: Text('${startTime.format(context)}'),
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: TextButton.icon(
+                                onPressed: () => pickTime(forStart: false),
+                                icon: const Icon(Icons.schedule),
+                                label: Text('${endTime.format(context)}'),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: locationController,
+                        decoration: const InputDecoration(
+                          labelText: 'Место',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: attendeesController,
+                        decoration: const InputDecoration(
+                          labelText: 'Участники (через запятую)',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      DropdownButtonFormField<int>(
+                        value: reminderMinutes,
+                        decoration: const InputDecoration(
+                          labelText: 'Напоминание',
+                          border: OutlineInputBorder(),
+                        ),
+                        items: const [
+                          DropdownMenuItem(value: 0, child: Text('Без напоминания')),
+                          DropdownMenuItem(value: 5, child: Text('За 5 минут')),
+                          DropdownMenuItem(value: 15, child: Text('За 15 минут')),
+                          DropdownMenuItem(value: 30, child: Text('За 30 минут')),
+                          DropdownMenuItem(value: 60, child: Text('За 1 час')),
+                        ],
+                        onChanged: (value) => setState(() => reminderMinutes = value ?? reminderMinutes),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Отмена'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    if (formKey.currentState?.validate() ?? false) {
+                      final startDateTime = isAllDay
+                          ? DateTime(selectedDate.year, selectedDate.month, selectedDate.day)
+                          : _combine(selectedDate, startTime);
+                      final endDateTime = isAllDay
+                          ? DateTime(selectedDate.year, selectedDate.month, selectedDate.day, 23, 59)
+                          : _combine(selectedDate, endTime);
+
+                      final attendees = attendeesController.text
+                          .split(',')
+                          .map((item) => item.trim())
+                          .where((item) => item.isNotEmpty)
+                          .toList();
+
+                      onSubmit(
+                        formData.copyWith(
+                          title: titleController.text.trim(),
+                          description: descriptionController.text.trim().isEmpty
+                              ? null
+                              : descriptionController.text.trim(),
+                          location: locationController.text.trim().isEmpty
+                              ? null
+                              : locationController.text.trim(),
+                          attendees: attendees,
+                          isAllDay: isAllDay,
+                          reminderMinutes: reminderMinutes,
+                          startDateTime: startDateTime,
+                          endDateTime: endDateTime,
+                        ),
+                      );
+
+                      Navigator.pop(context);
+                    }
+                  },
+                  child: const Text('Сохранить'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  DateTime _combine(DateTime date, TimeOfDay time) {
+    return DateTime(date.year, date.month, date.day, time.hour, time.minute);
+  }
+}
+
+class _EventsList extends StatelessWidget {
+  const _EventsList({
+    required this.events,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final List<Event> events;
+  final ValueChanged<Event> onEdit;
+  final ValueChanged<Event> onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: events.length,
+      itemBuilder: (context, index) {
+        final event = events[index];
+        return Card(
+          margin: const EdgeInsets.only(bottom: 12),
+          child: ListTile(
+            onTap: () => _showDetails(context, event),
+            leading: CircleAvatar(
+              backgroundColor: Theme.of(context).colorScheme.primary,
+              child: Text(
+                event.startTime.hour.toString().padLeft(2, '0'),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            title: Text(
+              event.title,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            subtitle: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (event.description != null) Text(event.description!),
+                const SizedBox(height: 4),
+                Text(
+                  event.isAllDay
+                      ? 'Весь день'
+                      : '${event.startTime.hour.toString().padLeft(2, '0')}:${event.startTime.minute.toString().padLeft(2, '0')} - '
+                        '${event.endTime.hour.toString().padLeft(2, '0')}:${event.endTime.minute.toString().padLeft(2, '0')}',
+                  style: TextStyle(color: Colors.grey[600], fontSize: 12),
+                ),
+                if (event.location != null)
+                  Text(
+                    '📍 ${event.location}',
+                    style: TextStyle(color: Colors.grey[600], fontSize: 12),
+                  ),
+              ],
+            ),
+            trailing: PopupMenuButton<String>(
+              onSelected: (value) {
+                if (value == 'edit') {
+                  onEdit(event);
+                } else if (value == 'delete') {
+                  onDelete(event);
+                }
+              },
+              itemBuilder: (context) => const [
+                PopupMenuItem(
+                  value: 'edit',
+                  child: Row(
+                    children: [
+                      Icon(Icons.edit),
+                      SizedBox(width: 8),
+                      Text('Редактировать'),
+                    ],
+                  ),
+                ),
+                PopupMenuItem(
+                  value: 'delete',
+                  child: Row(
+                    children: [
+                      Icon(Icons.delete),
+                      SizedBox(width: 8),
+                      Text('Удалить'),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _showDetails(BuildContext context, Event event) {
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                event.title,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 8),
+              if (event.description != null)
+                Text(
+                  event.description!,
+                  style: TextStyle(color: Colors.grey[700]),
+                ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  const Icon(Icons.schedule, size: 18),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      event.isAllDay
+                          ? 'Весь день'
+                          : '${event.startTime.hour.toString().padLeft(2, '0')}:${event.startTime.minute.toString().padLeft(2, '0')} - '
+                            '${event.endTime.hour.toString().padLeft(2, '0')}:${event.endTime.minute.toString().padLeft(2, '0')}',
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              if (event.location != null)
+                Row(
+                  children: [
+                    const Icon(Icons.place, size: 18),
+                    const SizedBox(width: 8),
+                    Expanded(child: Text(event.location!)),
+                  ],
+                ),
+              if (event.attendees.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                const Text('Участники:'),
+                const SizedBox(height: 4),
+                Wrap(
+                  spacing: 8,
+                  children: event.attendees
+                      .map((attendee) => Chip(label: Text(attendee)))
+                      .toList(),
+                ),
+              ],
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: () {
+                        Navigator.pop(context);
+                        onEdit(event);
+                      },
+                      icon: const Icon(Icons.edit),
+                      label: const Text('Редактировать'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: FilledButton.icon(
+                      onPressed: () {
+                        Navigator.pop(context);
+                        onDelete(event);
+                      },
+                      icon: const Icon(Icons.delete),
+                      label: const Text('Удалить'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.event_available, size: 64, color: Colors.grey[400]),
+          const SizedBox(height: 16),
+          Text(
+            'Нет событий',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Создайте ваше первое событие',
+            style: TextStyle(color: Colors.grey[600]),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CalendarError extends StatelessWidget {
+  const _CalendarError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.error_outline, size: 64, color: Colors.red[400]),
+          const SizedBox(height: 16),
+          Text(
+            'Ошибка загрузки календаря',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Colors.grey[600]),
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: () => context.read<CalendarBloc>().add(RefreshCalendar()),
+            child: const Text('Повторить'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventFormData {
+  const _EventFormData({
+    required this.id,
+    required this.title,
+    required this.startDateTime,
+    required this.endDateTime,
+    this.description,
+    this.location,
+    this.attendees = const [],
+    this.isAllDay = false,
+    this.reminderMinutes = 15,
+  });
+
+  final String id;
+  final String title;
+  final String? description;
+  final DateTime startDateTime;
+  final DateTime endDateTime;
+  final String? location;
+  final List<String> attendees;
+  final bool isAllDay;
+  final int reminderMinutes;
+
+  static _EventFormData initial({required DateTime selectedDate}) {
+    final id = 'event-${DateTime.now().microsecondsSinceEpoch}';
+    final start = DateTime(selectedDate.year, selectedDate.month, selectedDate.day, 9, 0);
+    final end = start.add(const Duration(hours: 1));
+    return _EventFormData(
+      id: id,
+      title: '',
+      startDateTime: start,
+      endDateTime: end,
+    );
+  }
+
+  static _EventFormData fromEvent(Event event) {
+    return _EventFormData(
+      id: event.id,
+      title: event.title,
+      description: event.description,
+      startDateTime: event.startTime,
+      endDateTime: event.endTime,
+      location: event.location,
+      attendees: event.attendees,
+      isAllDay: event.isAllDay,
+      reminderMinutes: event.reminderMinutes,
+    );
+  }
+
+  _EventFormData copyWith({
+    String? id,
+    String? title,
+    String? description,
+    DateTime? startDateTime,
+    DateTime? endDateTime,
+    String? location,
+    List<String>? attendees,
+    bool? isAllDay,
+    int? reminderMinutes,
+  }) {
+    return _EventFormData(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      startDateTime: startDateTime ?? this.startDateTime,
+      endDateTime: endDateTime ?? this.endDateTime,
+      location: location ?? this.location,
+      attendees: attendees ?? this.attendees,
+      isAllDay: isAllDay ?? this.isAllDay,
+      reminderMinutes: reminderMinutes ?? this.reminderMinutes,
     );
   }
 }

--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../../../../shared/widgets/bottom_nav_bar.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Главная')), 
+      body: const Center(
+        child: Text('Экран главной страницы в разработке'),
+      ),
+      bottomNavigationBar: const BottomNavBar(currentIndex: 0),
+    );
+  }
+}

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../../../../shared/widgets/bottom_nav_bar.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Настройки')),
+      body: const Center(
+        child: Text('Настройки в разработке'),
+      ),
+      bottomNavigationBar: const BottomNavBar(currentIndex: 3),
+    );
+  }
+}

--- a/lib/shared/widgets/bottom_nav_bar.dart
+++ b/lib/shared/widgets/bottom_nav_bar.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/navigation/app_router.dart';
+
+class BottomNavBar extends StatelessWidget {
+  const BottomNavBar({super.key, required this.currentIndex});
+
+  final int currentIndex;
+
+  void _onItemTapped(BuildContext context, int index) {
+    switch (index) {
+      case 0:
+        context.goNamed(AppRoute.home.name);
+        break;
+      case 1:
+        context.goNamed(AppRoute.calendar.name);
+        break;
+      case 2:
+        context.goNamed(AppRoute.assistant.name);
+        break;
+      case 3:
+        context.goNamed(AppRoute.settings.name);
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+      selectedIndex: currentIndex,
+      onDestinationSelected: (index) => _onItemTapped(context, index),
+      destinations: const [
+        NavigationDestination(
+          icon: Icon(Icons.home_outlined),
+          selectedIcon: Icon(Icons.home),
+          label: 'Главная',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.calendar_today_outlined),
+          selectedIcon: Icon(Icons.calendar_today),
+          label: 'Календарь',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.smart_toy_outlined),
+          selectedIcon: Icon(Icons.smart_toy),
+          label: 'Ассистент',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.settings_outlined),
+          selectedIcon: Icon(Icons.settings),
+          label: 'Настройки',
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add core application scaffolding for routing, theming, logging, and shared navigation widgets
- implement the calendar domain layer, in-memory remote datasource, repository, and bloc logic to support CRUD and search flows
- build an interactive calendar page with event create/edit dialogs, filtering, and placeholder pages for other navigation destinations

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ded7b7eb3c8327a24e2afed049b453